### PR TITLE
Delay the widget initialization

### DIFF
--- a/bootstrap3_datetime/widgets.py
+++ b/bootstrap3_datetime/widgets.py
@@ -78,9 +78,16 @@ class DateTimePicker(DateTimeInput):
     
     js_template = '''
         <script>
-            $(function() {
-                $("#%(picker_id)s").datetimepicker(%(options)s);
-            });
+            (function(window) {
+                var callback = function() {
+                    $(function(){$("#%(picker_id)s").datetimepicker(%(options)s);});
+                };
+                if(window.addEventListener)
+                    window.addEventListener("load", callback, false);
+                else if (window.attachEvent)
+                    window.attachEvent("onload", callback);
+                else window.onload = callback;
+            })(window);
         </script>'''
 
     def __init__(self, attrs=None, format=None, options=None, div_attrs=None, icon_attrs=None):


### PR DESCRIPTION
Many people like to place `{{ form.media }}` at the end of the page, in this case jQuery would not be loaded yet when the initialization runs (js_template). 

I'm not a javascript guy, perhaps there is a better way to delay the widget initialization, but this worked for me.
