### PR TITLE
django.forms.util renamed to django.forms.utils

### DIFF
--- a/bootstrap3_datetime/widgets.py
+++ b/bootstrap3_datetime/widgets.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from django.forms.util import flatatt
+from django.forms.utils import flatatt
 from django.forms.widgets import DateTimeInput
 from django.utils import translation
 from django.utils.safestring import mark_safe


### PR DESCRIPTION
django.forms.util is deprecated and will be removed in django 1.9
