### PR TITLE
do not enable datetimepicker on disabled or readonly fields

### DIFF
--- a/bootstrap3_datetime/widgets.py
+++ b/bootstrap3_datetime/widgets.py
@@ -91,7 +91,7 @@ class DateTimePicker(DateTimeInput):
         <script>
             (function(window) {
                 var callback = function() {
-                    $(function(){$("#%(picker_id)s").datetimepicker(%(options)s);});
+                    $(function(){$("#%(picker_id)s:has(input:not([readonly],[disabled]))").datetimepicker(%(options)s);});
                 };
                 if(window.addEventListener)
                     window.addEventListener("load", callback, false);


### PR DESCRIPTION
datetimepicker is able to change readonly fields which should not be done