### PR TITLE
Issue#28

### DIFF
--- a/bootstrap3_datetime/widgets.py
+++ b/bootstrap3_datetime/widgets.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import datetime
+
 from django.forms.util import flatatt
 from django.forms.widgets import DateTimeInput
 from django.utils import translation


### PR DESCRIPTION
TimeField return datetime.time as value and use a TimeInput. If we try to use a DateTimeInput we get error: "'datetime.time' object has no attribute 'year'", therefore bug not in Django. I try convert datetime.time to datetime.datetime before execute "force_text" and it works :)
