### PR TITLE
retro-compatibility with django 1.6

### DIFF
--- a/bootstrap3_datetime/widgets.py
+++ b/bootstrap3_datetime/widgets.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
-from django.forms.utils import flatatt
+from django import VERSION as DJANGO_VERSION
+if DJANGO_VERSION >= (1, 7):
+    from django.forms.utils import flatatt
+else:
+    from django.forms.util import flatatt
 from django.forms.widgets import DateTimeInput
 from django.utils import translation
 from django.utils.safestring import mark_safe


### PR DESCRIPTION
django.form.util deprecated in django 1.7 and will be removed in 1.9 but
django.form.utils not available in 1.6.
This commit avoid a deprecation warning and make the code django 1.9 ready.

This should solve #21
