### PR TITLE
unbreak django.forms.util(s) import for django < 1.7

### DIFF
--- a/bootstrap3_datetime/widgets.py
+++ b/bootstrap3_datetime/widgets.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
-from django.forms.utils import flatatt
+import django
+if django.VERSION >= (1,9):
+    from django.forms.utils import flatatt
+else:    
+    from django.forms.util import flatatt
 from django.forms.widgets import DateTimeInput
 from django.utils import translation
 from django.utils.safestring import mark_safe

--- a/bootstrap3_datetime/widgets.py
+++ b/bootstrap3_datetime/widgets.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import django
-if django.VERSION >= (1,9):
+if django.VERSION >= (1,7):
     from django.forms.utils import flatatt
 else:    
     from django.forms.util import flatatt


### PR DESCRIPTION
Django 1.6 and before will not work with the new import naming, and full removal of old path was not removed until 1.9. 

This conditionally imports the new name based on django version >= 1.9.

Tested locally in Django 1.6, and 1.7, and faked out the system by manually setting the version to 1.9 
