### PR TITLE
Get rid of .size()

### DIFF
--- a/bootstrap3_datetime/static/bootstrap3_datetime/js/bootstrap-datetimepicker.js
+++ b/bootstrap3_datetime/static/bootstrap3_datetime/js/bootstrap-datetimepicker.js
@@ -106,7 +106,7 @@ THE SOFTWARE.
             picker.component = false;
 
             if (picker.element.hasClass('input-group')) {
-                if (picker.element.find('.datepickerbutton').size() == 0) {//in case there is more then one 'input-group-addon' Issue #48
+                if (picker.element.find('.datepickerbutton').length == 0) {//in case there is more then one 'input-group-addon' Issue #48
                     picker.component = picker.element.find("[class^='input-group-']");
                 }
                 else {


### PR DESCRIPTION
#57 The .size() call has been deprecated as of JQ 1.8. A call to .length works and doesn't break the code.
