### PR TITLE
Removing erroneous option from widgets. 

### DIFF
--- a/bootstrap3_datetime/widgets.py
+++ b/bootstrap3_datetime/widgets.py
@@ -141,7 +141,6 @@ class DateTimePicker(DateTimeInput):
                                          input_attrs=flatatt(input_attrs),
                                          icon_attrs=flatatt(icon_attrs))
         if self.options:
-            self.options['language'] = translation.get_language()
             js = self.js_template % dict(picker_id=picker_id,
                                          options=json.dumps(self.options or {}))
         else:


### PR DESCRIPTION
The language option is no longer available in the datetimepicker's js so having it in there caused the widget to not display. I know this isn't a perfect fix as it would be better to set the locale option as well but this will at least get the widget to work.