### PR TITLE
Added Django 1.11 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 django-bootstrap3-datetimepicker
 ================================
 
+**This is a forked version of nkunihiko's datetimepicker with added support for Django 1.11
+
 This package uses Bootstrap v3 datetimepicker widget version 2 provided by the following project:
  https://github.com/Eonasdan/bootstrap-datetimepicker
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 django-bootstrap3-datetimepicker
 ================================
 
-**This is a forked version of nkunihiko's datetimepicker with added support for Django 1.11.
-
 This package uses Bootstrap v3 datetimepicker widget version 2 provided by the following project:
  https://github.com/Eonasdan/bootstrap-datetimepicker
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 django-bootstrap3-datetimepicker
 ================================
 
-**This is a forked version of nkunihiko's datetimepicker with added support for Django 1.11
+**This is a forked version of nkunihiko's datetimepicker with added support for Django 1.11.
 
 This package uses Bootstrap v3 datetimepicker widget version 2 provided by the following project:
  https://github.com/Eonasdan/bootstrap-datetimepicker

--- a/bootstrap3_datetime/widgets.py
+++ b/bootstrap3_datetime/widgets.py
@@ -151,7 +151,7 @@ class DateTimePicker(DateTimeInput):
             js = ''
         return mark_safe(force_text(html + js))
 
-        def build_attrs(self, base_attrs, extra_attrs=None, **kwargs):
+    def build_attrs(self, base_attrs, extra_attrs=None, **kwargs):
         attrs = dict(base_attrs, **kwargs)
         if extra_attrs:
             attrs.update(extra_attrs)

--- a/bootstrap3_datetime/widgets.py
+++ b/bootstrap3_datetime/widgets.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-from django.forms.utils import flatatt
+try:
+    from django.forms.utils import flatatt
+except ImportError:
+    from django.forms.util import flatatt
 from django.forms.widgets import DateTimeInput
 from django.utils import translation
 from django.utils.safestring import mark_safe
@@ -124,7 +127,7 @@ class DateTimePicker(DateTimeInput):
     def render(self, name, value, attrs=None):
         if value is None:
             value = ''
-        input_attrs = self.build_attrs(attrs, type=self.input_type, name=name)
+        input_attrs = self.build_attrs(self.attrs, attrs, type=self.input_type, name=name)
         if value != '':
             # Only add the 'value' attribute if a value is non-empty.
             input_attrs['value'] = force_text(self._format_value(value))
@@ -147,3 +150,9 @@ class DateTimePicker(DateTimeInput):
         else:
             js = ''
         return mark_safe(force_text(html + js))
+
+        def build_attrs(self, base_attrs, extra_attrs=None, **kwargs):
+        attrs = dict(base_attrs, **kwargs)
+        if extra_attrs:
+            attrs.update(extra_attrs)
+        return attrs


### PR DESCRIPTION
build_attrs was changed in Django 1.11. I added backwards compatible build_attrs function along with changing the flatatt import to work with later versions of Django.